### PR TITLE
Branched encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ If the field was not present in the encoded message, the decoded value will be s
 
 It acts as a static property on the encoded/decoded message, decoding will throw if the encoded value does not match the expected value.
 
+#### `const enc = either(encodings, test)`
+
+`either` encodes a value as one of a set of predefined encodings.
+
+`encodings` should be an array of compact-encodings and `test` should return the index in this array that should be used to encode a value.
+
+```js
+const enc = either([c.string, c.uint], value => {
+  return typeof value === string ? 0 : 1
+})
+````
+
 #### `{ header: header(enc, val) }`
 
 `header` encodes a value in the header at the start of the encoded message.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ It acts as a static property on the encoded/decoded message, decoding will throw
 
 ```js
 const enc = either([c.string, c.uint], value => {
-  return typeof value === string ? 0 : 1
+  return typeof value === 'string' ? 0 : 1
 })
 ````
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ module.exports = {
   array,
   constant,
   header,
-  getHeader
+  getHeader,
+  either
 }
 
 function compile (struct) {
@@ -174,6 +175,25 @@ module.exports.flag = {
   encode () {}, // ignore
   decode (state, header) {
     return !!header.flag.shift()
+  }
+}
+
+function either (encodings, test) {
+  return {
+    preencode (state, value) {
+      const index = test(value)
+      c.uint.preencode(state, index)
+      encodings[index].preencode(state, value)
+    },
+    encode (state, value) {
+      const index = test(value)
+      c.uint.encode(state, index)
+      encodings[index].encode(state, value)
+    },
+    decode (state) {
+      const index = c.uint.decode(state)
+      return encodings[index].decode(state)
+    }
   }
 }
 


### PR DESCRIPTION
Add an either function to encode a value that can be one of a set encodings.

Binary format: `<flag: c.uint || value: encoding>`

eg.
```
encodings = [c.string, c.buffer, c.uint]

string: Buffer<00 ..>
buffer: Buffer<01 ..>
uint:   Buffer<02 ..>
```