### PR TITLE
Only encode the header if optionals/flags are defined

### DIFF
--- a/test.js
+++ b/test.js
@@ -302,5 +302,10 @@ test('header encoding', t => {
   t.same(c.decode(struct, eorder), orderTest, 'order header')
   t.same(oheader, sheader, 'order get header')
 
+  const simple = compile({})
+  const enc = c.encode(simple, {})
+
+  t.equal(enc.byteLength, 0, 'no header')
+
   t.end()
 })


### PR DESCRIPTION
If no optionals/flags/headers are defined in the struct, then we do not encode the header and perform a simpler linear encoding of the rest of the fields.

eg.
```
encoding: { width: opt(c.uint), height: c.uint }
value: { width: 15, height: 8 } => Buffer<00 01 0f 08>

encoding: { width: c.uint, height: c.uint }
value: { width: 15, height: 8 } => Buffer<0f 08>
```